### PR TITLE
Add trove classifiers specifying Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,12 @@ setup(name='extras',
         'in the standard library'),
       long_description=get_long_description(),
       version=get_version(),
-      classifiers=["License :: OSI Approved :: MIT License"],
+      classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        ],
       packages=[
         'extras',
         'extras.tests',


### PR DESCRIPTION
In _setup.py_, I added additional trove classifiers to clarify that the package supports Python 3. Besides PyPI, this information is used by [caniusepython3](https://github.com/brettcannon/caniusepython3) and sites like http://py3readiness.org to determine if a package is Py3 ready.
