### PR TITLE
Fix Issue #5 -- Code is now PEP 396 compliant

### DIFF
--- a/extras/__init__.py
+++ b/extras/__init__.py
@@ -22,7 +22,8 @@ __all__ = [
 # If the releaselevel is 'final', then the tarball will be major.minor.micro.
 # Otherwise it is major.minor.micro~$(revno).
 
-__version__ = (0, 0, 3, 'final', 0)
+__version_info__ = (0, 0, 3, 'final', 0)
+__version__ = '.'.join([str(x) for x in __version_info__[0:3]])
 
 
 def try_import(name, alternative=None, error_callback=None):

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ testtools_cmd = extras.try_import('testtools.TestCommand')
 
 def get_version():
     """Return the version of extras that we are building."""
-    version = '.'.join(
-        str(component) for component in extras.__version__[0:3])
+    version = extras.__version__
     return version
 
 


### PR DESCRIPTION
`__version__` now returns a version string instead of a tuple. Added `__version_info__` which returns a version tuple.